### PR TITLE
Fix android project properties for samples.

### DIFF
--- a/collision/project.properties
+++ b/collision/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/eye-picking/project.properties
+++ b/eye-picking/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gamepad/project.properties
+++ b/gamepad/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-22
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-cubemap/project.properties
+++ b/gvr-cubemap/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-javascript/project.properties
+++ b/gvr-javascript/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-litshader/project.properties
+++ b/gvr-litshader/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-21
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-lua/project.properties
+++ b/gvr-lua/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-meshanimationsample/project.properties
+++ b/gvr-meshanimationsample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-21
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-outlinesample/project.properties
+++ b/gvr-outlinesample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-21
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-pickandmove/project.properties
+++ b/gvr-pickandmove/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-sample/project.properties
+++ b/gvr-sample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-test-screenshot3Dresult/project.properties
+++ b/gvr-test-screenshot3Dresult/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-testcube/project.properties
+++ b/gvr-testcube/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-video/project.properties
+++ b/gvr-video/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvr-vuforia/project.properties
+++ b/gvr-vuforia/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrbulletsample/project.properties
+++ b/gvrbulletsample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrcamera2renderscript/project.properties
+++ b/gvrcamera2renderscript/project.properties
@@ -12,5 +12,5 @@
 
 # Project target.
 target=android-21
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework
 renderscript.target=18

--- a/gvrcockpit_v1_5_0/project.properties
+++ b/gvrcockpit_v1_5_0/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrexposeapisample/project.properties
+++ b/gvrexposeapisample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrf_controls_sample/project.properties
+++ b/gvrf_controls_sample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrf_immersivepedia/project.properties
+++ b/gvrf_immersivepedia/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-21
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrf_keyboard_sample/project.properties
+++ b/gvrf_keyboard_sample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrf_minimal360photo/project.properties
+++ b/gvrf_minimal360photo/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrf_minimal360video/project.properties
+++ b/gvrf_minimal360video/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrjassimpmodelloader/project.properties
+++ b/gvrjassimpmodelloader/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvropacityanigallery/project.properties
+++ b/gvropacityanigallery/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrpanoramasstereoimagesample_v1_5_0/project.properties
+++ b/gvrpanoramasstereoimagesample_v1_5_0/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrperformancetest_v1_5_0/project.properties
+++ b/gvrperformancetest_v1_5_0/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrsixaxissensortest_v1_5_0/project.properties
+++ b/gvrsixaxissensortest_v1_5_0/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/gvrtextviewsample/project.properties
+++ b/gvrtextviewsample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/input-sample/project.properties
+++ b/input-sample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/lod-test/project.properties
+++ b/lod-test/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/model-viewer/project.properties
+++ b/model-viewer/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/nonglthreadupdate/project.properties
+++ b/nonglthreadupdate/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/scene-objects/project.properties
+++ b/scene-objects/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/simple-gallery/project.properties
+++ b/simple-gallery/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/simple-sample/project.properties
+++ b/simple-sample/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/solar-system/project.properties
+++ b/solar-system/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework

--- a/transparency-test/project.properties
+++ b/transparency-test/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework


### PR DESCRIPTION
Update the android library reference in 39 of the 40 sample projects,
reflecting the fact that the sample repo is now more likely to be in
a peer directory to the main repo, rather than a subdirectory.

GearVRf-DCO-1.0-Signed-off-by: John Spurlock
john.spurlock@gmail.com