### PR TITLE
gvr-renderableview: add .classpath, update framework location

### DIFF
--- a/gvr-renderableview/.classpath
+++ b/gvr-renderableview/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry kind="output" path="bin/classes"/>
+</classpath>

--- a/gvr-renderableview/project.properties
+++ b/gvr-renderableview/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../Framework
+android.library.reference.1=../../GearVRf/GVRf/Framework


### PR DESCRIPTION
* Framework location is now "../../GearVRf/GVRf/Framework", same as other
samples

Signed-off-by: Veeren Mandalia <veeren.mandalia@gmail.com>