### PR TITLE
gvr-immersivepedia: Fixed crash when displaying dinosaur text

### DIFF
--- a/gvrf_immersivepedia/src/org/gearvrf/immersivepedia/model/TextDinosaurGroup.java
+++ b/gvrf_immersivepedia/src/org/gearvrf/immersivepedia/model/TextDinosaurGroup.java
@@ -15,9 +15,13 @@
 
 package org.gearvrf.immersivepedia.model;
 
+import android.graphics.BitmapFactory;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.view.Gravity;
+import android.content.res.Resources;
 
 import org.gearvrf.GVRAndroidResource;
 import org.gearvrf.GVRContext;
@@ -147,8 +151,10 @@ public class TextDinosaurGroup extends GVRSceneObject implements TotemEventListe
     }
 
     private void createDinosaurTitle() {
+    	Resources resources = gvrContext.getActivity().getResources();
         String stringTitle = getGVRContext().getContext().getString(R.string.ankylosaurus_title);
-        Drawable background = gvrContext.getActivity().getDrawable(R.drawable.title_background);
+        Bitmap titleBitmap = BitmapFactory.decodeResource(resources, R.drawable.title_background);
+        BitmapDrawable background = new BitmapDrawable(resources, titleBitmap);
         title = new GVRTextViewSceneObject(gvrContext, TITLE_WIDTH, TITLE_HEIGHT, stringTitle);
         title.setRefreshFrequency(IntervalFrequency.LOW);
         title.setTextColor(Color.BLACK);
@@ -164,13 +170,12 @@ public class TextDinosaurGroup extends GVRSceneObject implements TotemEventListe
     private void createDinosaurDescription() {
         description = new GVRTextViewSceneObject(getGVRContext(), DESCRIPTION_WIDTH, DESCRIPTION_HEIGHT,
                 getGVRContext().getContext().getString(R.string.ankylosaurus_text));
-        Drawable background = gvrContext.getActivity().getDrawable(R.drawable.white_texture);
         description.setGravity(Gravity.LEFT);
         description.setTextColor(Color.BLACK);
         description.getTransform().setPositionY(2f);
         description.getRenderData().setRenderingOrder(RenderingOrderApplication.TEXT_BACKGROUND);
         description.setTextSize(5);
-        description.setBackGround(background);
+        description.setBackgroundColor(Color.WHITE);
         description.getTransform().setScale(0.3f, 0.3f, 0.3f);
         description.getTransform().setPosition(-.3f, 1.7f, 3f);
         addChildObject(description);


### PR DESCRIPTION
The text background needs to be a Drawable and the sample program relied on GVRActivity.getDrawable to obtain it. This function is new and not in android 19. We changed to code to convert the bitmap resource to a Drawable using another method. We changed the white background to just use a color instead of a texture.
GearVRf-DCO-1.0-Signed-off-by Nola Donato nola.donato@samsung.com