### PR TITLE
add a way to source other scripts from within a script

### DIFF
--- a/gvr-remote-scripting/gvrremotescript/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingManager.java
+++ b/gvr-remote-scripting/gvrremotescript/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingManager.java
@@ -54,6 +54,7 @@ public class GearVRScriptingManager extends GVRScript
         scriptManager.addVariable("editor", new EditorUtils(gvrContext));
         scriptManager.addVariable("passthrough", new PassthroughUtils(gvrContext, activity));
         scriptManager.addVariable("filebrowser", new FileBrowserUtils(gvrContext));
+        scriptManager.addVariable("source", new SourceUtils(gvrContext));
     }
 
     @Override

--- a/gvr-remote-scripting/gvrremotescript/src/main/java/org/gearvrf/sample/remote_scripting/SourceUtils.java
+++ b/gvr-remote-scripting/gvrremotescript/src/main/java/org/gearvrf/sample/remote_scripting/SourceUtils.java
@@ -1,0 +1,75 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gearvrf.sample.remote_scripting;
+
+import java.io.IOException;
+import java.net.URL;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.script.GVRScriptManager;
+import org.gearvrf.script.GVRScriptException;
+import org.gearvrf.script.GVRScriptFile;
+
+public class SourceUtils {
+    private GVRContext gvrContext;
+    private GVRScriptManager mScriptManager;
+
+    public SourceUtils(GVRContext context) {
+        gvrContext = context;
+        mScriptManager = gvrContext.getScriptManager();
+    }
+
+    // from assets directory 
+    public void script(String filename, String language) {
+        try {
+            GVRAndroidResource resource = new GVRAndroidResource(gvrContext, filename);
+            GVRScriptFile script = mScriptManager.loadScript(resource, language);
+            script.invoke();
+        } catch(IOException e) {
+            e.printStackTrace();
+        } catch(GVRScriptException se) {
+            se.printStackTrace();
+        }
+    }
+
+    // from /sdcard directory 
+    public void scriptFromSD(String filename, String language) {
+        try {
+            GVRAndroidResource resource = new GVRAndroidResource(filename);
+            GVRScriptFile script = mScriptManager.loadScript(resource, language);
+            script.invoke();
+        } catch(IOException e) {
+            e.printStackTrace();
+        } catch(GVRScriptException se) {
+            se.printStackTrace();
+        }
+    }
+
+    // from a URL 
+    public void scriptFromURL(URL url, String language) {
+        try {
+            GVRAndroidResource resource = new GVRAndroidResource(gvrContext, url);
+            GVRScriptFile script = mScriptManager.loadScript(resource, language);
+            script.invoke();
+        } catch(IOException e) {
+            e.printStackTrace();
+        } catch(GVRScriptException se) {
+            se.printStackTrace();
+        }
+    }
+
+}
+


### PR DESCRIPTION
A feature request from our artist:  be able to source script files from within a script.
The api is similar to loading a model.  to source a script from the assets/ directory call:
source.script("filename", "language");  // where 'language' is "lua" or "js"
source.scriptFromSD() loads from sdcard
source.scriptFromURL() loads from url.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com