### PR TITLE
fix package name used by gradle.

### DIFF
--- a/gvr-remote-scripting/build.gradle
+++ b/gvr-remote-scripting/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/gvr-remote-scripting/gvrremotescript/build.gradle
+++ b/gvr-remote-scripting/gvrremotescript/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        applicationId "com.samsung.android.gvr.sample"
+        applicationId "org.gearvrf.sample.remote_scripting"
         minSdkVersion 19
         targetSdkVersion 19
     }


### PR DESCRIPTION
fix package name used by gradle.   upgrade to gradle 2.1.0 since
AndroidStudio keeps asking me to do it anyway.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com