### PR TITLE
Fix coding error in gvr-exposeapi

### DIFF
--- a/gvr-exposeapi/gvrexposeapi/src/main/java/org/gearvrf/gvrexposeapi/SampleActivity.java
+++ b/gvr-exposeapi/gvrexposeapi/src/main/java/org/gearvrf/gvrexposeapi/SampleActivity.java
@@ -33,7 +33,8 @@ public class SampleActivity extends GVRActivity {
 
 
     @Override
-    protected void onInitAppSettings(VrAppSettings appSettings){
+    protected void onInitAppSettings(VrAppSettings appSettings) {
+        super.onInitAppSettings(appSettings);
         appSettings.getEyeBufferParms().setMultiSamples(2);
         VrAppSettings.setShowDebugLog(true);
     }


### PR DESCRIPTION
SampleActivity.onInitAppSettings should call the base class function

GearVRf-DCO-1.0-Signed-off-by: NolaDonato nola.donato@samsung.com