### PR TITLE
gvr-3dcursor: fixed the relative path for io_template

### DIFF
--- a/gvr-3dcursor/settings.gradle
+++ b/gvr-3dcursor/settings.gradle
@@ -16,8 +16,12 @@
 include 'app'
 include ':framework'
 include ':3DCursorLibrary'
+
 //_VENDOR_TODO_ add your device folder here for Android Studio to locate it
 //include ':IODevices:io_template'
+//project(':IODevices:io_template').projectDir =
+//        new File("../../GearVRf/GVRf/Extensions/3DCursor/IODevices/io_template")
+
 project(':framework').projectDir = new File('../../GearVRf/GVRf/Framework/framework')
 project(':3DCursorLibrary').projectDir = new File("../../GearVRf/GVRf/Extensions/3DCursor/" +
         "3DCursorLibrary")


### PR DESCRIPTION
Added a line comment to make it easier to locate the IODevices
folder.

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com