### PR TITLE
Revert to GVRScript for now

### DIFF
--- a/gvr-camera2renderscript/gvrcamera2renderscript/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptActivity.java
+++ b/gvr-camera2renderscript/gvrcamera2renderscript/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptActivity.java
@@ -12,7 +12,7 @@ public class Camera2RenderscriptActivity extends GVRActivity
         super.onCreate(icicle);
 
         mManger = new Camera2RenderscriptManager(this);
-        setMain(mManger, "gvr.xml");
+        setScript(mManger, "gvr.xml");
     }
 	
     @Override

--- a/gvr-camera2renderscript/gvrcamera2renderscript/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptManager.java
+++ b/gvr-camera2renderscript/gvrcamera2renderscript/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptManager.java
@@ -1,12 +1,13 @@
 package org.gearvrf.gvrcamera2renderscript;
 
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRMain;
 import org.gearvrf.GVRActivity;
 import org.gearvrf.GVRExternalTexture;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRMaterial.GVRShaderType;
+import org.gearvrf.GVRScript;
+
 import android.graphics.SurfaceTexture;
 import android.hardware.camera2.*;
 import android.renderscript.RenderScript;
@@ -15,7 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import android.view.Surface;
 
-public class Camera2RenderscriptManager extends GVRMain
+public class Camera2RenderscriptManager extends GVRScript
 {
 	private GVRActivity mActivity;
 	private RenderScript mRS;


### PR DESCRIPTION
A temporary fix for exception in gvr-camera2renderscript app happening due to updating SurfaceTexture in non GL thread. Correct fix in a new pull request.

GearVRf-DCO-1.0-Signed-off-by: Deepak Rawat
deepak.rawat@samsung.com