### PR TITLE
Immersivepedia - move some of the processing off the gl thread

### DIFF
--- a/gvr-immersivepedia/gvrimmersivepedia/src/main/java/org/gearvrf/immersivepedia/focus/FocusableController.java
+++ b/gvr-immersivepedia/gvrimmersivepedia/src/main/java/org/gearvrf/immersivepedia/focus/FocusableController.java
@@ -26,10 +26,11 @@ import org.gearvrf.immersivepedia.R;
 import org.gearvrf.immersivepedia.input.TouchPadInput;
 
 import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class FocusableController {
 
-    public static ArrayList<FocusableSceneObject> interactiveObjects = new ArrayList<FocusableSceneObject>();
+    public static CopyOnWriteArrayList<FocusableSceneObject> interactiveObjects = new CopyOnWriteArrayList<FocusableSceneObject>();
 
     public static void process(GVRContext context) {
 


### PR DESCRIPTION
- should help with really bad stuttering when passing over the totems

- avoid ConcurrentModificationException when iterating over interactiveObjects
- preload the loadingComponent's mesh and textures instead of loading them on every pass over the totem
- move to a background thread some of the audio-related processing

--
This is just a first pass. There might be subsequent changes in other PRs.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>
