### PR TITLE
gvr-immersivepedia: fix NPE crash

### DIFF
--- a/gvr-immersivepedia/gvrimmersivepedia/src/main/java/org/gearvrf/immersivepedia/Main.java
+++ b/gvr-immersivepedia/gvrimmersivepedia/src/main/java/org/gearvrf/immersivepedia/Main.java
@@ -85,17 +85,18 @@ public class Main extends GVRScript {
 		FocusableController.swipeProcess(mGvrContext);
 	}
 
-	public static void clickOut() {
-		if (mGvrContext.getMainScene().equals(Main.dinosaurScene)) {
-			Main.dinosaurScene.closeObjectsInScene();
-		}
-	}
+    public static void clickOut() {
+        if (null != dinosaurScene && mGvrContext.getMainScene().equals(Main.dinosaurScene)) {
+            Main.dinosaurScene.closeObjectsInScene();
+        }
+    }
 
-	public void onPause() {
-		if (null != mediaPlayer) {
-			mediaPlayer.stop();
-		}
-
-		dinosaurScene.onPause();
-	}
+    public void onPause() {
+        if (null != mediaPlayer) {
+            mediaPlayer.stop();
+        }
+        if (null != dinosaurScene) {
+            dinosaurScene.onPause();
+        }
+    }
 }


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>

--

```
06-07 14:45:01.136 26607 26607 E AndroidRuntime: FATAL EXCEPTION: main
06-07 14:45:01.136 26607 26607 E AndroidRuntime: Process: org.gearvrf.immersivepedia, PID: 26607
06-07 14:45:01.136 26607 26607 E AndroidRuntime: java.lang.RuntimeException: Unable to pause activity {org.gearvrf.immersivepedia/org.gearvrf.immersivepedia.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.gearvrf.immersivepedia.scene.DinosaurScene.onPause()' on a null object reference
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4659)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4618)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:5465)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.access$1200(ActivityThread.java:226)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1849)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.os.Handler.dispatchMessage(Handler.java:102)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.os.Looper.loop(Looper.java:158)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.main(ActivityThread.java:7522)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at java.lang.reflect.Method.invoke(Native Method)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.gearvrf.immersivepedia.scene.DinosaurScene.onPause()' on a null object reference
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at org.gearvrf.immersivepedia.Main.onPause(Main.java:99)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at org.gearvrf.immersivepedia.MainActivity.onPause(MainActivity.java:76)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.Activity.performPause(Activity.java:7033)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1339)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4645)
06-07 14:45:01.136 26607 26607 E AndroidRuntime: ... 10 more
```