### PR TITLE
Use debugwebserver in  gvr-remote-scripting sample

### DIFF
--- a/gvr-remote-scripting/app/build.gradle
+++ b/gvr-remote-scripting/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "org.gearvrf.sample.remote_scripting"
         minSdkVersion 19
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -33,4 +33,5 @@ android {
 
 dependencies {
     compile project(':framework')
+    compile project(':debugwebserver')
 }

--- a/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScripting.java
+++ b/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScripting.java
@@ -38,6 +38,7 @@ public class GearVRScripting extends GVRActivity
     String ipAddress;
     private Camera camera;
     private Handler handler = new Handler();
+    private GearVRScriptingMain main;
 
     /** Called when the activity is first created. */
     @Override
@@ -47,8 +48,8 @@ public class GearVRScripting extends GVRActivity
 
         ipAddress = getWifiIpAddress(this);
         createCameraView();
-
-        setMain(new GearVRScriptingMain(), "gvr.xml");
+        main = new GearVRScriptingMain();
+        setMain(main, "gvr.xml");
     }
 
     @Override
@@ -123,5 +124,11 @@ public class GearVRScripting extends GVRActivity
         return camera;
     }
 
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        main.stop();
+    }
 
 }

--- a/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingMain.java
+++ b/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingMain.java
@@ -15,30 +15,37 @@
 
 package org.gearvrf.sample.remote_scripting;
 
-import org.gearvrf.GVRMain;
-import org.gearvrf.GVRContext;
-import org.gearvrf.GVRScene;
-import org.gearvrf.scene_objects.GVRTextViewSceneObject;
 import android.view.Gravity;
+
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRMain;
+import org.gearvrf.GVRScene;
+import org.gearvrf.debug.DebugServer;
+import org.gearvrf.scene_objects.GVRTextViewSceneObject;
 import org.gearvrf.script.GVRScriptManager;
 
-public class GearVRScriptingMain extends GVRMain
-{
+import smcl.samsung.com.debugwebserver.DebugWebServer;
 
+public class GearVRScriptingMain extends GVRMain {
+    private static final String TAG = GearVRScriptingMain.class.getSimpleName();
+    private static final int DEBUG_SERVER_PORT = 5000;
+    DebugWebServer server;
+    private GVRContext gvrContext;
     @Override
     public void onInit(GVRContext gvrContext) {
-        gvrContext.startDebugServer();
         GVRScene scene = gvrContext.getNextMainScene();
-
+        this.gvrContext = gvrContext;
         // get the ip address
         GearVRScripting activity = (GearVRScripting) gvrContext.getActivity();
         String ipAddress = activity.getIpAddress();
-        String telnetString = "telnet " + ipAddress + " 1645";
+        String debugUrl = "http://" + ipAddress + ":" + DEBUG_SERVER_PORT;
+        String telnetString = "telnet " + ipAddress + " " + DebugServer.DEFAULT_DEBUG_PORT;
 
         // create text object to tell the user where to connect
-        GVRTextViewSceneObject textViewSceneObject = new GVRTextViewSceneObject(gvrContext, telnetString);
+        GVRTextViewSceneObject textViewSceneObject = new GVRTextViewSceneObject(gvrContext, 2.0f,
+                0.5f, debugUrl + "\n" + telnetString);
         textViewSceneObject.setGravity(Gravity.CENTER);
-        textViewSceneObject.setTextSize(8);
+        textViewSceneObject.setTextSize(5);
         textViewSceneObject.getTransform().setPosition(0.0f, 0.0f, -3.0f);
 
         // make sure to set a name so we can reference it when we log in
@@ -55,10 +62,21 @@ public class GearVRScriptingMain extends GVRMain
         scriptManager.addVariable("passthrough", new PassthroughUtils(gvrContext, activity));
         scriptManager.addVariable("filebrowser", new FileBrowserUtils(gvrContext));
         scriptManager.addVariable("source", new SourceUtils(gvrContext));
+
+        gvrContext.startDebugServer();
+        server = new DebugWebServer(gvrContext);
+        server.listen(DEBUG_SERVER_PORT);
+
     }
 
     @Override
     public void onStep() {
     }
 
+    public void stop() {
+        if(server != null) {
+            server.stop();
+        }
+        gvrContext.stopDebugServer();
+    }
 }

--- a/gvr-remote-scripting/app/src/main/project.properties
+++ b/gvr-remote-scripting/app/src/main/project.properties
@@ -13,3 +13,4 @@
 # Project target.
 target=android-19
 android.library.reference.1=../../../../../GearVRf/GVRf/Framework/framework/src/main
+android.library.reference.2=../../../../../GearVRf/GVRf/Extensions/debugwebserver/src/main

--- a/gvr-remote-scripting/build.gradle
+++ b/gvr-remote-scripting/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/gvr-remote-scripting/settings.gradle
+++ b/gvr-remote-scripting/settings.gradle
@@ -1,3 +1,4 @@
-include ':framework'
+include ':framework', ':debugwebserver'
 include ':app'
 project(':framework').projectDir = new File('../../GearVRf/GVRf/Framework/framework')
+project(':debugwebserver').projectDir = new File('../../GearVRf/GVRf/Extensions/debugwebserver')


### PR DESCRIPTION
Using the debugwebserver extension in the gvr-remote-scripting
sample instead of telnet based debug server.

depends on https://github.com/Samsung/GearVRf/pull/638