### PR TITLE
Revert gvr-simplegallery to GVRScript for now

### DIFF
--- a/gvr-simplegallery/app/src/main/java/org/gearvrf/simplegallery/GalleryActivity.java
+++ b/gvr-simplegallery/app/src/main/java/org/gearvrf/simplegallery/GalleryActivity.java
@@ -25,6 +25,6 @@ public class GalleryActivity extends GVRActivity {
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
-        setMain(new GalleryMain(), "gvr.xml");
+        setScript(new GalleryMain(), "gvr.xml");
     }
 }

--- a/gvr-simplegallery/app/src/main/java/org/gearvrf/simplegallery/GalleryMain.java
+++ b/gvr-simplegallery/app/src/main/java/org/gearvrf/simplegallery/GalleryMain.java
@@ -26,6 +26,7 @@ import org.gearvrf.GVRRenderData.GVRRenderMaskBit;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRMain;
+import org.gearvrf.GVRScript;
 import org.gearvrf.GVRTexture;
 import org.gearvrf.animation.GVRAnimation;
 import org.gearvrf.animation.GVRAnimationEngine;
@@ -36,7 +37,7 @@ import org.gearvrf.scene_objects.GVRVideoSceneObject.GVRVideoType;
 
 import android.media.MediaPlayer;
 
-public class GalleryMain extends GVRMain {
+public class GalleryMain extends GVRScript {
 
     private static final float ANIMATION_DURATION = 0.3f;
     private static final float SELECTED_SCALE = 2.0f;


### PR DESCRIPTION
GVRMain causes the app to crash. Reverting it to
GVRScript till it can be fixed.

GearVRf-DCO-1.0-Signed-off-by: Rahul Rudradevan
r.rudradevan@samsung.com