### PR TITLE
gvr-remote-scripting: fix a npe

### DIFF
--- a/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingMain.java
+++ b/gvr-remote-scripting/app/src/main/java/org/gearvrf/sample/remote_scripting/GearVRScriptingMain.java
@@ -77,6 +77,8 @@ public class GearVRScriptingMain extends GVRMain {
         if(server != null) {
             server.stop();
         }
-        gvrContext.stopDebugServer();
+        if (null != gvrContext){
+            gvrContext.stopDebugServer();
+        }
     }
 }


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>


```
07-14 08:19:16.010 27172 27172 E AndroidRuntime: FATAL EXCEPTION: main
07-14 08:19:16.010 27172 27172 E AndroidRuntime: Process: org.gearvrf.sample.remote_scripting, PID: 27172
07-14 08:19:16.010 27172 27172 E AndroidRuntime: java.lang.RuntimeException: Unable to destroy activity {org.gearvrf.sample.remote_scripting/org.gearvrf.sample.remote_scripting.GearVRScripting}: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.gearvrf.GVRContext.stopDebugServer()' on a null object reference
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5143)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5166)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.app.ActivityThread.access$1700(ActivityThread.java:226)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1902)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:158)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7522)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
07-14 08:19:16.010 27172 27172 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```