### PR TITLE
Make gvr-widget-viewer compatible with aar build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ovr_sdk_mobile/
 ////////////////////////
 *.prefs
 *.so
+*.aar
 
 /////////////////////////
 // Ignored Files        /

--- a/gvr-widgetviewer/app/build.gradle
+++ b/gvr-widgetviewer/app/build.gradle
@@ -42,5 +42,5 @@ android {
 
 dependencies {
     compile(name:'framework-debug', ext:'aar')
-    compile(name:'widget_plugin-debug', ext:'aar')
+    compile(name:'widgetplugin-debug', ext:'aar')
 }

--- a/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/GVRWidgetViewer.java
+++ b/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/GVRWidgetViewer.java
@@ -54,7 +54,7 @@ public class GVRWidgetViewer extends GVRActivity implements
         mMain = new ViewerMain(mPlugin);
         mPlugin.setCurrentScript(mMain);
         mWidget.mMain = mMain;
-        setMain(mMain, "gvr.xml");
+        setScript(mMain, "gvr.xml");
     }
 
     @Override

--- a/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/ViewerMain.java
+++ b/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/ViewerMain.java
@@ -25,7 +25,7 @@ import android.opengl.GLES20;
 import android.util.Log;
 import android.view.MotionEvent;
 
-public class ViewerMain extends GVRMain {
+public class ViewerMain extends GVRScript {
 
     private static final String TAG = "ViewerMain";
 


### PR DESCRIPTION
1. Added aar to gitignore for ignoring .aar files in gearvf-libs directory
2. gvr-widgetviewer was not working with GVRMain. Switching to GVRScript for now.
3. gvr-widgetviewer needs change in build.gradle as module name for widget plugin has changed

depends on https://github.com/Samsung/GearVRf/pull/726