### PR TITLE
valueFloatTexture must be set when create circle alpha

### DIFF
--- a/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/loadComponent/LoadComponent.java
+++ b/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/loadComponent/LoadComponent.java
@@ -78,6 +78,8 @@ public class LoadComponent extends GVRSceneObject implements FocusListener {
                 .setShaderType(new CutoutShader(gvrContext).getShaderId());
         circleAlpha.getRenderData().getMaterial()
                 .setTexture(CutoutShader.TEXTURE_KEY, circleAlphaTexture);
+        circleAlpha.getRenderData().getMaterial()
+                .setFloat(CutoutShader.CUTOUT, valueFloatTexture);
         circleAlpha.getRenderData().setRenderingOrder(RenderingOrderApplication.LOADING_COMPONENT);
         circleAlpha.getRenderData().getMaterial().setMainTexture(circleAlphaTexture);
         circle.setName("circle");


### PR DESCRIPTION
If not set first time render result in error and error shader is called

GearVRf-DCO-1.0-Signed-off-by: 
Deepak Rawat deepak.rawat@samsung.com