### PR TITLE
add the framework outputs directory

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -2,7 +2,7 @@ allprojects {
     repositories {
         jcenter()
         flatDir {
-            dirs '../../gearvrf-libs'
+            dirs '../../gearvrf-libs', '../../../GearVRf/GVRf/Framework/framework/build/outputs/aar'
         }
     }
 }


### PR DESCRIPTION
I probably missed the memo due to travel and other chaos i was handling,
  but would this commit be useful?  I'm adding the relative path to
  where the framework aar should be given the way we usually clone the
  repos.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com