### PR TITLE
Looks like gvr-keyboard depends on the order of execution of

### DIFF
--- a/gvr-keyboard/app/src/main/java/org/gearvrf/keyboard/spinner/SpinnerItem.java
+++ b/gvr-keyboard/app/src/main/java/org/gearvrf/keyboard/spinner/SpinnerItem.java
@@ -37,10 +37,12 @@ public class SpinnerItem extends TextFieldItem {
     public void updateText(GVRContext context) {
         if (cacheTestOn) {
 
-            GVRBitmapTexture tex = new GVRBitmapTexture(context, SpinnerItemFactory.getInstance(
-                    getGVRContext()).getBitmap(charItem.getMode(),
-                    charItem.getPosition()));
-            getRenderData().getMaterial().setMainTexture(tex);
+            if (null != charItem) {
+                GVRBitmapTexture tex = new GVRBitmapTexture(context, SpinnerItemFactory.getInstance(
+                        getGVRContext()).getBitmap(charItem.getMode(),
+                        charItem.getPosition()));
+                getRenderData().getMaterial().setMainTexture(tex);
+            }
 
         } else {
             GVRBitmapTexture tex = new GVRBitmapTexture(context, GVRTextBitmapFactory.create(


### PR DESCRIPTION
onStep and drawframeListeners on startup; we have not defined that
so you can't assume anything

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>