### PR TITLE
up the resolution on the spheres used in the 360 samples.

### DIFF
--- a/gvr-360photo/app/src/main/java/org/gearvrf/gvr360Photo/Minimal360PhotoMain.java
+++ b/gvr-360photo/app/src/main/java/org/gearvrf/gvr360Photo/Minimal360PhotoMain.java
@@ -22,6 +22,7 @@ import org.gearvrf.GVRContext;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRMain;
 import org.gearvrf.GVRTexture;
+import org.gearvrf.GVRMaterial;
 import org.gearvrf.scene_objects.GVRSphereSceneObject;
 
 public class Minimal360PhotoMain extends GVRMain {
@@ -38,7 +39,9 @@ public class Minimal360PhotoMain extends GVRMain {
         Future<GVRTexture> texture = gvrContext.loadFutureTexture(new GVRAndroidResource(gvrContext, R.raw.photosphere));
 
         // create a sphere scene object with the specified texture and triangles facing inward (the 'false' argument) 
-        sphereObject = new GVRSphereSceneObject(gvrContext, false, texture);
+        GVRMaterial material = new GVRMaterial(gvrContext);
+        material.setMainTexture(texture);
+        sphereObject = new GVRSphereSceneObject(gvrContext, 72, 144, false, material);
 
         // add the scene object to the scene graph
         scene.addSceneObject(sphereObject);

--- a/gvr-360video/app/src/main/java/org/gearvrf/gvr360video/Minimal360Video.java
+++ b/gvr-360video/app/src/main/java/org/gearvrf/gvr360video/Minimal360Video.java
@@ -29,7 +29,7 @@ import org.gearvrf.GVRMain;
 import org.gearvrf.GVRMesh;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRCameraRig;
-import org.gearvrf.GVRMain;
+import org.gearvrf.GVRMaterial;
 import org.gearvrf.scene_objects.GVRSphereSceneObject;
 import org.gearvrf.scene_objects.GVRVideoSceneObject;
 import org.gearvrf.scene_objects.GVRVideoSceneObject.GVRVideoType;
@@ -46,7 +46,8 @@ public class Minimal360Video extends GVRMain
         scene.getMainCameraRig().getTransform().setPosition( 0.0f, 0.0f, 0.0f );
 
         // create sphere / mesh
-        GVRSphereSceneObject sphere = new GVRSphereSceneObject(gvrContext, false);
+        GVRMaterial material = new GVRMaterial(gvrContext);
+        GVRSphereSceneObject sphere = new GVRSphereSceneObject(gvrContext, 72, 144, false, material);
         GVRMesh mesh = sphere.getRenderData().getMesh();
 
         // create mediaplayer instance


### PR DESCRIPTION
up the resolution on the spheres used in the 360 samples.

we're getting more and more questions about the quality of photos / videos when viewed in these samples.  they all boil down to the default resolution of the GVRSphereSceneObject.  I don't want to up the resolution on that by default because i don't want to accidentally slow down other apps.  But the 360 photo and video samples need the higher resolution, so, we'll up the resolution in the app.  Sometime later (maybe this weekend), i'll add some convenience constructors for GVRSphereSceneObject so the number of lines needed to set this up is back to the original number of lines.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com