### PR TITLE
gvr-eyepicking: explicitly set the shader version for the custom shader

### DIFF
--- a/gvr-eyepicking/app/src/main/java/org/gearvrf/gvreyepicking/ColorShader.java
+++ b/gvr-eyepicking/app/src/main/java/org/gearvrf/gvreyepicking/ColorShader.java
@@ -44,7 +44,7 @@ public class ColorShader extends GVRShaderTemplate
 
     public ColorShader(GVRContext gvrContext)
     {
-        super("float4 u_color");
+        super("float4 u_color", 300);
         setSegment("FragmentTemplate", FRAGMENT_SHADER);
         setSegment("VertexTemplate", VERTEX_SHADER);
     }


### PR DESCRIPTION
After the change to support version 100 and 300 shaders the default version became 100. This sample uses 300 and needs to explicitly mention that now. Not sure whether 100 as default in the framework is better than 300 but I'll leave it be.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>