### PR TITLE
Add command line option to enable building the demos with an

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -31,7 +31,19 @@ preBuild {}.dependsOn copyOculusSignature
 
 dependencies {
     compile(name: 'framework-debug', ext: 'aar')
-    compile(name: 'backend-debug', ext: 'aar')
+    if (rootProject.hasProperty("no_oculus")) {
+        if (file('../../gearvrf-libs/backend-debug.aar').exists()) {
+            compile(name: 'backend-debug', ext: 'aar')
+        } else {
+            throw new GradleException('No backend aar available!')
+        }
+    } else {
+        if (file('../../gearvrf-libs/backend_oculus-debug.aar').exists()) {
+            compile(name: 'backend_oculus-debug', ext: 'aar')
+        } else {
+            throw new GradleException('No backend aar available!')
+        }
+    }
     compile(name: 'google-vr-base', ext: 'aar')
     compile(name: 'google-vr-common', ext: 'aar')
 }


### PR DESCRIPTION
alternative backend; by default oculus will be used

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>