### PR TITLE
gvr-nonglthreadupdate: use the default text size for the gvrconsole

### DIFF
--- a/gvr-nonglthreadupdate/app/src/main/java/org/gearvrf/nonglthreadupdate/SampleMain.java
+++ b/gvr-nonglthreadupdate/app/src/main/java/org/gearvrf/nonglthreadupdate/SampleMain.java
@@ -45,7 +45,7 @@ public class SampleMain extends GVRScript {
 
         GVRScene scene = gvrContext.getNextMainScene();
         mConsole = new GVRConsole(gvrContext, EyeMode.BOTH_EYES, gvrContext.getNextMainScene());
-        mConsole.setTextSize(mConsole.getTextSize() * 3);
+
         // set background color
         GVRCameraRig mainCameraRig = scene.getMainCameraRig();
         mainCameraRig.getLeftCamera()


### PR DESCRIPTION
Needs to go in together with https://github.com/Samsung/GearVRf/pull/900

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>