### PR TITLE
Include 64bit binaries only when the custom ARM64 property is defined

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -37,6 +37,9 @@ android {
     packagingOptions {
         exclude 'lib/x86/libgvrbase.so'
         exclude 'lib/arm64-v8a/libgvrbase.so'
+        if (!rootProject.hasProperty("ARM64")) {
+            exclude 'lib/arm64-v8a/*.so'
+        }
     }
 }
 


### PR DESCRIPTION
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>