### PR TITLE
Add a buildGvrfAndDemos gradle property. When set it changes the

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -19,6 +19,8 @@ android {
 
     buildTypes {
         debug {
+            debuggable = true
+            jniDebuggable = true
             resValue 'string', 'app_name', System.getProperty("appName")
         }
         release {
@@ -81,35 +83,61 @@ if(!rootProject.hasProperty("useLocalDependencies")) {
 ext.gearvrfVersion='3.1.1-SNAPSHOT'
 project.ext.jomlVersion = "1.9.1-SNAPSHOT"
 
-dependencies {
-    compile "org.joml:joml-android:${jomlVersion}"
-    if(rootProject.useLocalDependencies) {
+if(rootProject.useLocalDependencies) {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
         compile(name: 'framework-debug', ext: 'aar')
-    } else {
-        compile "org.gearvrf:framework:$gearvrfVersion"
-    }
 
-    if (rootProject.hasProperty("only_daydream")) {
-        if(rootProject.useLocalDependencies) {
+        if (rootProject.hasProperty("only_daydream")) {
             compile(name: 'backend_daydream-debug', ext: 'aar')
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
         } else {
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-        }
-        compile 'com.google.vr:sdk-base:1.10.0'
-        compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
-    } else {
-        if (rootProject.hasProperty("no_oculus")) {
-            compile(name: 'backend-debug', ext: 'aar')
-        } else { //default oculus+daydream
-            if(rootProject.useLocalDependencies) {
+            if (rootProject.hasProperty("no_oculus")) {
+                compile(name: 'backend-debug', ext: 'aar')
+            } else { //default oculus+daydream
                 compile(name: 'backend_daydream-debug', ext: 'aar')
                 compile(name: 'backend_oculus-debug', ext: 'aar')
-            } else {
-                compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-                compile "org.gearvrf:backend_oculus:$gearvrfVersion"
+                compile 'com.google.vr:sdk-base:1.10.0'
+                compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
             }
+        }
+    }
+} else if(rootProject.hasProperty("buildGvrfAndDemos")) {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
+        compile project (':framework')
+
+        if (rootProject.hasProperty("only_daydream")) {
+            compile project (':backend_daydream')
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+        } else {
+            if (rootProject.hasProperty("no_oculus")) {
+                compile project (':backend')
+            } else { //default oculus+daydream
+                compile project (':backend_oculus')
+                compile project (':backend_daydream')
+                compile 'com.google.vr:sdk-base:1.10.0'
+                compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+            }
+        }
+    }
+} else {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
+        compile "org.gearvrf:framework:$gearvrfVersion"
+
+        if (rootProject.hasProperty("only_daydream")) {
+            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+        } else { //default oculus+daydream
+            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            compile "org.gearvrf:backend_oculus:$gearvrfVersion"
             compile 'com.google.vr:sdk-base:1.10.0'
             compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
         }
     }
 }
+

--- a/gvr-simplesample/build.gradle
+++ b/gvr-simplesample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/gvr-simplesample/gradle/wrapper/gradle-wrapper.properties
+++ b/gvr-simplesample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 19 18:16:14 PDT 2016
+#Wed Jan 04 09:52:32 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/old/common.gradle
+++ b/old/common.gradle
@@ -19,6 +19,8 @@ android {
 
     buildTypes {
         debug {
+            debuggable = true
+            jniDebuggable = true
             resValue 'string', 'app_name', System.getProperty("appName")
         }
         release {
@@ -61,6 +63,13 @@ task copyOculusSignature(type: Copy) {
 
 preBuild {}.dependsOn copyOculusSignature
 
+/*
+To use local dependencies add the following line in a global gradle properties file
+eg. ~/.gradle/gradle.properties:
+
+useLocalDependencies=true
+
+ */
 if(!rootProject.hasProperty("useLocalDependencies")) {
     rootProject.ext.useLocalDependencies=false;
 } else {
@@ -74,35 +83,61 @@ if(!rootProject.hasProperty("useLocalDependencies")) {
 ext.gearvrfVersion='3.1.1-SNAPSHOT'
 project.ext.jomlVersion = "1.9.1-SNAPSHOT"
 
-dependencies {
-    compile "org.joml:joml-android:${jomlVersion}"
-    if(rootProject.useLocalDependencies) {
+if(rootProject.useLocalDependencies) {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
         compile(name: 'framework-debug', ext: 'aar')
-    } else {
-        compile "org.gearvrf:framework:$gearvrfVersion"
-    }
 
-    if (rootProject.hasProperty("only_daydream")) {
-        if(rootProject.useLocalDependencies) {
+        if (rootProject.hasProperty("only_daydream")) {
             compile(name: 'backend_daydream-debug', ext: 'aar')
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
         } else {
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-        }
-        compile 'com.google.vr:sdk-base:1.10.0'
-        compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
-    } else {
-        if (rootProject.hasProperty("no_oculus")) {
-            compile(name: 'backend-debug', ext: 'aar')
-        } else { //default oculus+daydream
-            if(rootProject.useLocalDependencies) {
+            if (rootProject.hasProperty("no_oculus")) {
+                compile(name: 'backend-debug', ext: 'aar')
+            } else { //default oculus+daydream
                 compile(name: 'backend_daydream-debug', ext: 'aar')
                 compile(name: 'backend_oculus-debug', ext: 'aar')
-            } else {
-                compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-                compile "org.gearvrf:backend_oculus:$gearvrfVersion"
+                compile 'com.google.vr:sdk-base:1.10.0'
+                compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
             }
+        }
+    }
+} else if(rootProject.hasProperty("buildGvrfAndDemos")) {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
+        compile project (':framework')
+
+        if (rootProject.hasProperty("only_daydream")) {
+            compile project (':backend_daydream')
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+        } else {
+            if (rootProject.hasProperty("no_oculus")) {
+                compile project (':backend')
+            } else { //default oculus+daydream
+                compile project (':backend_oculus')
+                compile project (':backend_daydream')
+                compile 'com.google.vr:sdk-base:1.10.0'
+                compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+            }
+        }
+    }
+} else {
+    dependencies {
+        compile "org.joml:joml-android:${jomlVersion}"
+        compile "org.gearvrf:framework:$gearvrfVersion"
+
+        if (rootProject.hasProperty("only_daydream")) {
+            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            compile 'com.google.vr:sdk-base:1.10.0'
+            compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+        } else { //default oculus+daydream
+            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            compile "org.gearvrf:backend_oculus:$gearvrfVersion"
             compile 'com.google.vr:sdk-base:1.10.0'
             compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
         }
     }
 }
+


### PR DESCRIPTION
dependencies so the demos can be built together with the framework
and the backends.

Set buildGvrfAndDemos to true in gradle.properties and then add
the demo module to extra_settings.gradle; e.g.

include ':gvr-simplesample'
project(':gvr-simplesample').projectDir=new File('<insert-your-path-here/GearVRf-Demos/gvr-simplesample/app')

Do note that the "app" directory has to be referenced.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>