### PR TITLE
Oculus Mobile SDK 1.5.0: support 64bit build with the Oculus backend

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -44,10 +44,11 @@ android {
 
     // ignore the x86 and arm-v8 files from the google vr libraries
     packagingOptions {
-        exclude 'lib/x86/libgvr.so'
-        exclude 'lib/arm64-v8a/libgvr.so'
         if (!rootProject.hasProperty("ARM64")) {
-            exclude 'lib/arm64-v8a/*.so'
+            exclude 'lib/x86/libgvr.so'
+            exclude 'lib/arm64-v8a/libgvr.so'
+        } else {
+            exclude 'lib/armeabi-v7a/*.so'
         }
     }
 }
@@ -99,11 +100,13 @@ if(rootProject.useLocalDependencies) {
                 debugCompile(name: 'backend-debug', ext: 'aar')
                 releaseCompile(name: 'backend-release', ext: 'aar')
             } else { //default oculus+daydream
-                debugCompile(name: 'backend_daydream-debug', ext: 'aar')
-                releaseCompile(name: 'backend_daydream-release', ext: 'aar')
+                if (!rootProject.hasProperty("ARM64")) {
+                    debugCompile(name: 'backend_daydream-debug', ext: 'aar')
+                    releaseCompile(name: 'backend_daydream-release', ext: 'aar')
+                    compile 'com.google.vr:sdk-base:1.30.0'
+                }
                 debugCompile(name: 'backend_oculus-debug', ext: 'aar')
                 releaseCompile(name: 'backend_oculus-release', ext: 'aar')
-                compile 'com.google.vr:sdk-base:1.30.0'
             }
         }
     }
@@ -120,8 +123,10 @@ if(rootProject.useLocalDependencies) {
                 compile project (':backend')
             } else { //default oculus+daydream
                 compile project (':backend_oculus')
-                compile project (':backend_daydream')
-                compile 'com.google.vr:sdk-base:1.30.0'
+                if (!rootProject.hasProperty("ARM64")) {
+                    compile project (':backend_daydream')
+                    compile 'com.google.vr:sdk-base:1.30.0'
+                }
             }
         }
     }
@@ -134,9 +139,11 @@ if(rootProject.useLocalDependencies) {
             compile "org.gearvrf:backend_daydream:$gearvrfVersion"
             compile 'com.google.vr:sdk-base:1.30.0'
         } else { //default oculus+daydream
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            if (!rootProject.hasProperty("ARM64")) {
+                compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+                compile 'com.google.vr:sdk-base:1.30.0'
+            }
             compile "org.gearvrf:backend_oculus:$gearvrfVersion"
-            compile 'com.google.vr:sdk-base:1.30.0'
         }
     }
 }

--- a/old/common.gradle
+++ b/old/common.gradle
@@ -44,10 +44,11 @@ android {
 
     // ignore the x86 and arm-v8 files from the google vr libraries
     packagingOptions {
-        exclude 'lib/x86/libgvr.so'
-        exclude 'lib/arm64-v8a/libgvr.so'
         if (!rootProject.hasProperty("ARM64")) {
+            exclude 'lib/x86/libgvr.so'
             exclude 'lib/arm64-v8a/*.so'
+        } else {
+            exclude 'lib/armeabi-v7a/*.so'
         }
     }
 }
@@ -99,11 +100,13 @@ if(rootProject.useLocalDependencies) {
                 debugCompile(name: 'backend-debug', ext: 'aar')
                 releaseCompile(name: 'backend-release', ext: 'aar')
             } else { //default oculus+daydream
-                debugCompile(name: 'backend_daydream-debug', ext: 'aar')
-                releaseCompile(name: 'backend_daydream-release', ext: 'aar')
+                if (!rootProject.hasProperty("ARM64")) {
+                    debugCompile(name: 'backend_daydream-debug', ext: 'aar')
+                    releaseCompile(name: 'backend_daydream-release', ext: 'aar')
+                    compile 'com.google.vr:sdk-base:1.30.0'
+                }
                 debugCompile(name: 'backend_oculus-debug', ext: 'aar')
                 releaseCompile(name: 'backend_oculus-release', ext: 'aar')
-                compile 'com.google.vr:sdk-base:1.30.0'
             }
         }
     }
@@ -120,8 +123,10 @@ if(rootProject.useLocalDependencies) {
                 compile project (':backend')
             } else { //default oculus+daydream
                 compile project (':backend_oculus')
-                compile project (':backend_daydream')
-                compile 'com.google.vr:sdk-base:1.30.0'
+                if (!rootProject.hasProperty("ARM64")) {
+                    compile project (':backend_daydream')
+                    compile 'com.google.vr:sdk-base:1.30.0'
+                }
             }
         }
     }
@@ -134,9 +139,11 @@ if(rootProject.useLocalDependencies) {
             compile "org.gearvrf:backend_daydream:$gearvrfVersion"
             compile 'com.google.vr:sdk-base:1.30.0'
         } else { //default oculus+daydream
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+            if (!rootProject.hasProperty("ARM64")) {
+                compile "org.gearvrf:backend_daydream:$gearvrfVersion"
+                compile 'com.google.vr:sdk-base:1.30.0'
+            }
             compile "org.gearvrf:backend_oculus:$gearvrfVersion"
-            compile 'com.google.vr:sdk-base:1.30.0'
         }
     }
 }


### PR DESCRIPTION
Prerequisite: https://github.com/Samsung/GearVRf/pull/1093

If the ARM64 property is defined the build will produce apk using the 64bit binaries. Daydream is automatically disabled in this case.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>