### PR TITLE
gvr-camera2renderscript: fix crash on S8

### DIFF
--- a/gvr-camera2renderscript/app/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptActivity.java
+++ b/gvr-camera2renderscript/app/src/main/java/org/gearvrf/gvrcamera2renderscript/Camera2RenderscriptActivity.java
@@ -1,20 +1,20 @@
 package org.gearvrf.gvrcamera2renderscript;
 
-import org.gearvrf.GVRActivity;
 import android.os.Bundle;
 
-public class Camera2RenderscriptActivity extends GVRActivity 
-{
-	private Camera2RenderscriptManager mManger;
-	
-	@Override
+import org.gearvrf.GVRActivity;
+
+public class Camera2RenderscriptActivity extends GVRActivity {
+    private Camera2RenderscriptManager mManger;
+
+    @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
 
         mManger = new Camera2RenderscriptManager(this);
         setMain(mManger);
     }
-	
+
     @Override
     protected void onPause() {
         super.onPause();

--- a/gvr-camera2renderscript/app/src/main/java/org/gearvrf/gvrcamera2renderscript/RenderscriptProcessor.java
+++ b/gvr-camera2renderscript/app/src/main/java/org/gearvrf/gvrcamera2renderscript/RenderscriptProcessor.java
@@ -29,7 +29,7 @@ public class RenderscriptProcessor
         String model = Build.MODEL;
         Log.d("MODEL", model);
         if (model.contains("SM-N920") || model.contains("SM-G920") || model.contains("SM-G925") || model.contains("SM-G928")
-                || model.contains("SM-G93") || model.contains("SM-N9208")) {
+                || model.contains("SM-G93") || model.contains("SM-N9208") || model.contains("SM-G95")) {
             mNeedYuvConversion = true;
         }
 


### PR DESCRIPTION
Looks like you can tell at runtime whether the yuv-rgb conversion is necessary (it is for all recent phones apparently). I can't find a phone that doesn't need the conversion so can't verify. I probably need a Note4 with Android L. KitKat just doesn't work due to the use of 21 apis. For now using the old and tried method.

---
GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>