### PR TITLE
gvr-modelviewer2: Fix the build from maven

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-org.gradle.parallel=false
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048M

--- a/gvr-modelviewer2/app/build.gradle
+++ b/gvr-modelviewer2/app/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    if(rootProject.useLocalDependencies || rootProject.buildGvrfAndDemos) {
+    if(rootProject.useLocalDependencies || (rootProject.hasProperty("buildGvrfAndDemos") && rootProject.buildGvrfAndDemos)) {
         compile(name: 'widgetplugin-debug', ext: 'aar')
     } else {
         compile "org.gearvrf:widgetplugin:$gearvrfVersion"

--- a/old/gradle.properties
+++ b/old/gradle.properties
@@ -1,3 +1,2 @@
-org.gradle.parallel=false
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
+ remove unnecessary property from gradle.property

Needed for the 3.2 release


Removing the org.gradle.parallel allows setting it in the global gradle.properties to true. Building in parallel seems to work pretty good nowadays and there is a great speedup when building and installing the demos.