### PR TITLE
Apply the scale to the video, not the sphere.

### DIFF
--- a/gvr-360video/app/src/main/java/org/gearvrf/gvr360video/Minimal360Video.java
+++ b/gvr-360video/app/src/main/java/org/gearvrf/gvr360video/Minimal360Video.java
@@ -38,10 +38,10 @@ public class Minimal360Video extends GVRMain
         // create sphere / mesh
         GVRSphereSceneObject sphere = new GVRSphereSceneObject(gvrContext, 72, 144, false);
         GVRMesh mesh = sphere.getRenderData().getMesh();
-        sphere.getTransform().setScale(100f, 100f, 100f);
 
         // create video scene
         GVRVideoSceneObject video = new GVRVideoSceneObject( gvrContext, mesh, mPlayer, GVRVideoType.MONO );
+        video.getTransform().setScale(100f, 100f, 100f);
         video.setName( "video" );
 
         // apply video to scene


### PR DESCRIPTION
Setting the scale on the sphere tells the renderer what matrix to apply
when rendering that SphereSceneObject.  however, we're not using the
SphereSceneObject, but rather the vertices from the sphere.  So, apply
the scale to the VideoSceneObject instead.

GearVRf-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com