### PR TITLE
gvr-accessibility: Fix for the inverted colors option not working

### DIFF
--- a/gvr-accessibility/app/src/main/java/com/samsung/accessibility/scene/AccessibilityScene.java
+++ b/gvr-accessibility/app/src/main/java/com/samsung/accessibility/scene/AccessibilityScene.java
@@ -184,8 +184,6 @@ public class AccessibilityScene extends GVRScene {
 
     private void applyShader(AccessibilitySceneShader shader, GVRSceneObject object) {
         if (object != null && object.getRenderData() != null && object.getRenderData().getMaterial() != null) {
-            GVRMaterial material = new GVRMaterial(gvrContext, GVRMaterial.GVRShaderType.BeingGenerated.ID);
-            object.getRenderData().setMaterial(material);
             object.getRenderData().getMaterial().setTexture(AccessibilitySceneShader.TEXTURE_KEY,
                     object.getRenderData().getMaterial().getMainTexture());
             object.getRenderData().getMaterial().setFloat(AccessibilitySceneShader.BLUR_INTENSITY, 1);


### PR DESCRIPTION
Again, the merge and squash github did dropped the change from my pull request..