### PR TITLE
Fix all occurrences of GL_OES_EGL_image_external

### DIFF
--- a/gvr-video/app/src/main/java/org/gearvrf/video/shaders/RadiosityShader.java
+++ b/gvr-video/app/src/main/java/org/gearvrf/video/shaders/RadiosityShader.java
@@ -33,7 +33,8 @@ public class RadiosityShader extends GVRShader {
     public static final String LIGHT_KEY = "u_lightness";
 
     private static final String VERTEX_SHADER = "" //
-            + "#extension GL_OES_EGL_image_external_essl3 : require\n"
+            + "#extension GL_OES_EGL_image_external : enable\n"
+            + "#extension GL_OES_EGL_image_external_essl3 : enable\n"
             + "precision highp float;\n"
             + "in vec3 a_position;\n"
             + "in vec3 a_normal;\n"

--- a/gvr-video/app/src/main/java/org/gearvrf/video/shaders/ScreenShader.java
+++ b/gvr-video/app/src/main/java/org/gearvrf/video/shaders/ScreenShader.java
@@ -38,7 +38,8 @@ public class ScreenShader extends GVRShader{
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
-            + "#extension GL_OES_EGL_image_external_essl3 : require\n"
+            + "#extension GL_OES_EGL_image_external : enable\n"
+            + "#extension GL_OES_EGL_image_external_essl3 : enable\n"
             + "precision mediump float;\n"
             + "uniform samplerExternalOES u_screen;\n"
             + "varying vec2 v_tex_coord;\n"


### PR DESCRIPTION
Different phone models need different extensions for samplerExternalOES:
Adreno-based, GL_OES_EGL_image_external_essl3
Mali-based, GL_OES_EGL_image_external
Instead of 'require' a particular extension in the fragment shader, 'enable' both.