### PR TITLE
Fix EGL_image_external

### DIFF
--- a/gvr-blurfilter/app/src/main/res/raw/gaussianblurhorz.fsh
+++ b/gvr-blurfilter/app/src/main/res/raw/gaussianblurhorz.fsh
@@ -1,4 +1,5 @@
-#extension GL_OES_EGL_image_external : require
+#extension GL_OES_EGL_image_external : enable
+#extension GL_OES_EGL_image_external_essl3 : enable
 precision highp float;
 uniform float u_resolution;
 uniform samplerExternalOES main_texture;

--- a/gvr-blurfilter/app/src/main/res/raw/gaussianblurvert.fsh
+++ b/gvr-blurfilter/app/src/main/res/raw/gaussianblurvert.fsh
@@ -1,4 +1,5 @@
-#extension GL_OES_EGL_image_external : require
+#extension GL_OES_EGL_image_external : enable
+#extension GL_OES_EGL_image_external_essl3 : enable
 precision highp float;
 uniform float u_resolution;
 uniform samplerExternalOES u_texture;

--- a/gvr-video/app/src/main/java/org/gearvrf/video/shaders/RadiosityShader.java
+++ b/gvr-video/app/src/main/java/org/gearvrf/video/shaders/RadiosityShader.java
@@ -29,7 +29,8 @@ public class RadiosityShader extends GVRShaderTemplate{
     public static final String LIGHT_KEY = "u_lightness";
 
     private static final String VERTEX_SHADER = "" //
-            + "#extension GL_OES_EGL_image_external : require\n"
+            + "#extension GL_OES_EGL_image_external : enable\n"
+            + "#extension GL_OES_EGL_image_external_essl3 : enable\n"
             + "precision highp float;\n"
             + "attribute vec4 a_position;\n"
             + "attribute vec3 a_normal;\n"

--- a/gvr-video/app/src/main/java/org/gearvrf/video/shaders/ScreenShader.java
+++ b/gvr-video/app/src/main/java/org/gearvrf/video/shaders/ScreenShader.java
@@ -36,7 +36,8 @@ public class ScreenShader {
             + "}\n";
 
     private static final String FRAGMENT_SHADER = "" //
-            + "#extension GL_OES_EGL_image_external : require\n"
+            + "#extension GL_OES_EGL_image_external : enable\n"
+            + "#extension GL_OES_EGL_image_external_essl3 : enable\n"
             + "precision mediump float;\n"
             + "uniform samplerExternalOES u_screen;\n"
             + "varying vec2 v_tex_coord;\n"


### PR DESCRIPTION
Different phone models need different extensions for samplerExternalOES:
Adreno-based, GL_OES_EGL_image_external_essl3
Mali-based, GL_OES_EGL_image_external
Instead of 'require' a particular extension in the fragment shader, 'enable' both.