### PR TITLE
gvr-cubemap: reflective sphere is back

### DIFF
--- a/gvr-cubemap/app/src/main/java/org/gearvrf/cubemap/CubemapMain.java
+++ b/gvr-cubemap/app/src/main/java/org/gearvrf/cubemap/CubemapMain.java
@@ -248,7 +248,7 @@ public class CubemapMain extends GVRMain {
 
         if (sphere != null) {
             sphere.setName("sphere");
-//            scene.addSceneObject(sphere);
+            scene.addSceneObject(sphere);
             sphere.getTransform().setScale(SCALE_FACTOR, SCALE_FACTOR,
                     SCALE_FACTOR);
             sphere.getTransform().setPosition(0.0f, 0.0f, -CUBE_WIDTH * 0.25f);


### PR DESCRIPTION
Fix: reflective sphere was removed by accident