### PR TITLE
releasing media player is time consuming.

### DIFF
--- a/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/videoComponent/VideoComponent.java
+++ b/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/videoComponent/VideoComponent.java
@@ -46,7 +46,6 @@ public class VideoComponent extends GVRSceneObject {
     private static final float DURATION = 0.5f;
 
     private boolean active = false;
-    private boolean closeVideo;
 
     private GVRVideoSceneObject video;
     private FocusableSceneObject focus;
@@ -199,16 +198,12 @@ public class VideoComponent extends GVRSceneObject {
     }
 
     public void hideVideo() {
+        active = false;
         mediaPlayer.stop();
         mediaPlayer.release();
         mediaPlayer = null;
         new GVROpacityAnimation(this, .1f, 0).start(gvrContext.getAnimationEngine());
         gvrContext.getMainScene().removeSceneObject(this);
-        active = false;
-    }
-
-    public boolean isCloseVideo() {
-        return closeVideo;
     }
 
     public boolean isActive() {


### PR DESCRIPTION
fixes #211 

`active` flag is disabled only after media player is released, but it is checked possibly during the release.