### PR TITLE
gradle: rework the way backends are specified

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -1,8 +1,8 @@
-if(file("../../../extra_properties.gradle").exists()) {
+if (file("../../../extra_properties.gradle").exists()) {
     apply from: '../../../extra_properties.gradle'
 }
 
-if(file("../../../../extra_properties.gradle").exists()) {
+if (file("../../../../extra_properties.gradle").exists()) {
     apply from: '../../../../extra_properties.gradle'
 }
 
@@ -77,75 +77,92 @@ eg. ~/.gradle/gradle.properties:
 useLocalDependencies=true
 
  */
-ext.gearvrfVersion='4.0.1-SNAPSHOT'
+ext.gearvrfVersion = '4.0.1-SNAPSHOT'
 project.ext.daydreamVersion = '1.120.0'
 project.ext.jomlVersion = "1.9.3-SNAPSHOT"
-project.ext.gsonVersion='2.8.2'
+project.ext.gsonVersion = '2.8.2'
 
-if(project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
-    dependencies {
-        compile "com.google.code.gson:gson:$gsonVersion"
-        compile "org.joml:joml-android:${jomlVersion}"
+def hasBackend = false
+if (project.hasProperty("backend_monoscopic") && project.property("backend_monoscopic")) {
+    hasBackend = true
+} else if (project.hasProperty("backend_daydream") && project.property("backend_daydream")) {
+    hasBackend = true
+} else if (project.hasProperty("backend_oculus") && project.property("backend_oculus")) {
+    hasBackend = true
+} else if (project.hasProperty("backend") && project.property("backend")) {
+    hasBackend = true
+}
+if (!hasBackend) {
+    project.ext.backend_oculus = true
+    project.ext.backend_daydream = true
+}
 
+dependencies {
+    compile "com.google.code.gson:gson:$gsonVersion"
+    compile "org.joml:joml-android:${jomlVersion}"
+
+    if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
         if (findProject(':framework')) {
             compile project(':framework')
         } else {
             debugCompile(name: 'framework-debug', ext: 'aar')
             releaseCompile(name: 'framework-release', ext: 'aar')
         }
+    } else {
+        compile "org.gearvrf:framework:$gearvrfVersion"
+    }
 
-        if (project.hasProperty("only_daydream")) {
+    if (project.hasProperty("backend_monoscopic") && project.property("backend_monoscopic")) {
+        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+            if (findProject(':backend_monoscopic')) {
+                compile project(':backend_monoscopic')
+            } else {
+                debugCompile(name: 'backend_monoscopic-debug', ext: 'aar')
+                releaseCompile(name: 'backend_monoscopic-release', ext: 'aar')
+            }
+        } else {
+            compile "org.gearvrf:backend_monoscopic:$gearvrfVersion"
+        }
+    }
+
+    if (project.hasProperty("backend_daydream") && project.property("backend_daydream")) {
+        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
             if (findProject(':backend_daydream')) {
                 compile project(':backend_daydream')
             } else {
                 debugCompile(name: 'backend_daydream-debug', ext: 'aar')
                 releaseCompile(name: 'backend_daydream-release', ext: 'aar')
             }
-            compile "com.google.vr:sdk-base:${daydreamVersion}"
-            compile "com.google.vr:sdk-controller:${daydreamVersion}"
         } else {
-            if (project.hasProperty("no_oculus")) {
-                if (findProject(':backend')) {
-                    compile project(':backend')
-                } else {
-                    debugCompile(name: 'backend-debug', ext: 'aar')
-                    releaseCompile(name: 'backend-release', ext: 'aar')
-                }
-            } else { //default oculus+daydream
-                if (findProject(':backend_daydream')) {
-                    compile project(':backend_daydream')
-                } else {
-                    debugCompile(name: 'backend_daydream-debug', ext: 'aar')
-                    releaseCompile(name: 'backend_daydream-release', ext: 'aar')
-                }
-                compile "com.google.vr:sdk-base:${daydreamVersion}"
-                compile "com.google.vr:sdk-controller:${daydreamVersion}"
-
-                if (findProject(':backend_oculus')) {
-                    compile project(':backend_oculus')
-                } else {
-                    debugCompile(name: 'backend_oculus-debug', ext: 'aar')
-                    releaseCompile(name: 'backend_oculus-release', ext: 'aar')
-                }
-            }
+            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
         }
+        compile "com.google.vr:sdk-base:${daydreamVersion}"
+        compile "com.google.vr:sdk-controller:${daydreamVersion}"
     }
-} else {
-    dependencies {
-        compile "com.google.code.gson:gson:$gsonVersion"
-        compile "org.joml:joml-android:${jomlVersion}"
-        compile "org.gearvrf:framework:$gearvrfVersion"
 
-        if (project.hasProperty("only_daydream")) {
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-            compile "com.google.vr:sdk-base:${daydreamVersion}"
-            compile "com.google.vr:sdk-controller:${daydreamVersion}"
-        } else { //default oculus+daydream
-            compile "org.gearvrf:backend_daydream:$gearvrfVersion"
-            compile "com.google.vr:sdk-base:${daydreamVersion}"
-            compile "com.google.vr:sdk-controller:${daydreamVersion}"
+    if (project.hasProperty("backend_oculus") && project.property("backend_oculus")) {
+        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+            if (findProject(':backend_oculus')) {
+                compile project(':backend_oculus')
+            } else {
+                debugCompile(name: 'backend_oculus-debug', ext: 'aar')
+                releaseCompile(name: 'backend_oculus-release', ext: 'aar')
+            }
+        } else {
             compile "org.gearvrf:backend_oculus:$gearvrfVersion"
         }
     }
-}
 
+    if (project.hasProperty("backend") && project.property("backend")) {
+        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+            if (findProject(':backend')) {
+                compile project(':backend')
+            } else {
+                debugCompile(name: 'backend-debug', ext: 'aar')
+                releaseCompile(name: 'backend-release', ext: 'aar')
+            }
+        } else {
+            throw new GradleException("backend not available from maven")
+        }
+    }
+}


### PR DESCRIPTION
Replace the archaic way of specifying the backends to use with, e.g.:

```
		backend_oculus=false
		backend_daydream=false
		backend_monoscopic=true
		backend=false
```

If none specified defaults to oculus+daydream, as before.

``no_oculus, only_daydream`` are being removed.