### PR TITLE
gvr-modelviewer2, gvr-widgetviewer: tweaks to make them work better

### DIFF
--- a/gvr-modelviewer2/app/src/main/java/org/gearvrf/modelviewer2/ModelViewer2Activity.java
+++ b/gvr-modelviewer2/app/src/main/java/org/gearvrf/modelviewer2/ModelViewer2Activity.java
@@ -16,7 +16,6 @@
 package org.gearvrf.modelviewer2;
 
 import android.os.Bundle;
-import android.util.DisplayMetrics;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 
@@ -71,10 +70,7 @@ public class ModelViewer2Activity extends GVRActivity
         mDetector = new GestureDetector(getBaseContext(), swipeListener);
         mWidget = new MyMenu();
         mPlugin = new GVRWidgetPlugin(this, mWidget);
-
-        DisplayMetrics displaymetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-        mPlugin.setViewSize(displaymetrics.widthPixels, displaymetrics.heightPixels);
+        mPlugin.setViewSize(2560, 1440);
 
         //SkyBox List
         mManager = new ModelViewer2Manager(this, mPlugin);

--- a/gvr-modelviewer2/app/src/main/java/org/gearvrf/modelviewer2/MyMenu.java
+++ b/gvr-modelviewer2/app/src/main/java/org/gearvrf/modelviewer2/MyMenu.java
@@ -376,8 +376,4 @@ public class MyMenu extends GVRWidget {
     public void dispose() {
         mStage.dispose();
     }
-
-    public boolean needsGL20() {
-        return false;
-    }
 }

--- a/gvr-widgetviewer/app/src/main/assets/gvr.xml
+++ b/gvr-widgetviewer/app/src/main/assets/gvr.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--/* Copyright 2015 Samsung Electronics Co., LTD
+<?xml version="1.0" encoding="UTF-8"?><!--/* Copyright 2015 Samsung Electronics Co., LTD
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,45 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */-->
-
-
-
-<lens name="N4" >
-
-    <vr-app-settings
-        framebufferPixelsHigh="DEFAULT"
-        framebufferPixelsWide="DEFAULT"
-        showLoadingIcon="true"
-        useProtectedFramebuffer="false"
-        useControllerTypes="gaze,controller"
-        useSrgbFramebuffer="false" >
-
-        <mono-mode-parms
-            monoFullScreen="false"
-            monoMode="false" />
-
-        <mode-parms
-            allowPowerSave="true"
-            resetWindowFullScreen="true" />
-
-        <performance-parms
-            cpuLevel="2"
-            gpuLevel="2" />
-
-        <eye-buffer-parms
-            colorFormat="COLOR_8888"
-            depthFormat="DEPTH_24"
-            fov-y="90.0"
-            multiSamples="2"
-            resolutionWidth="DEFAULT"
-            resolutionHeight="DEFAULT"
-            resolveDepth="false" />
-
-        <head-model-parms
-            eyeHeight="DEFAULT"
-            headModelDepth="DEFAULT"
-            headModelHeight="DEFAULT"
-            interpupillaryDistance="DEFAULT" />
-    </vr-app-settings>
-
-</lens>
+<vr-app-settings showLoadingIcon="true" useControllerTypes="gaze,controller">
+    <performance-parms cpuLevel="2" gpuLevel="2" />
+    <eye-buffer-parms colorFormat="COLOR_8888" depthFormat="DEPTH_24" multiSamples="2" />
+</vr-app-settings>

--- a/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/GVRWidgetViewer.java
+++ b/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/GVRWidgetViewer.java
@@ -61,10 +61,7 @@ public class GVRWidgetViewer extends GVRActivity
         mWidget = new MyGdxWidget();
         mPlugin = new GVRWidgetPlugin(this, mWidget);
 
-        DisplayMetrics displaymetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-        mPlugin.setViewSize(displaymetrics.widthPixels,
-                displaymetrics.heightPixels);
+        mPlugin.setViewSize(2560, 1440);
         mDetector = new GestureDetector(getBaseContext(), mSwipeListener);
 
         mMain = new ViewerMain(mPlugin);
@@ -127,7 +124,6 @@ public class GVRWidgetViewer extends GVRActivity
                 } else {
                     mMain.mRotateY = (dx / 2 + mYangle - mMoveoffset) % 360;
                 }
-                Log.d("NOLA", "onTouchEvent rotateY = %f", mMain.mRotateY);
             }
         }
         return true;

--- a/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/MyGdxWidget.java
+++ b/gvr-widgetviewer/app/src/main/java/org/gearvrf/widgetViewer/MyGdxWidget.java
@@ -16,18 +16,18 @@
 package org.gearvrf.widgetViewer;
 
 
-import org.gearvrf.utility.Log;
-import org.gearvrf.widgetplugin.GVRWidget;
-
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
-import com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane.ScrollPaneStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
@@ -36,12 +36,11 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Slider;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
+
+import org.gearvrf.widgetplugin.GVRWidget;
 
 public class MyGdxWidget extends GVRWidget {
 
@@ -57,8 +56,6 @@ public class MyGdxWidget extends GVRWidget {
     public ViewerMain mMain;
     Button mNextButton;
     Button mPreviousButton;
-    Button mColorButton;
-    Button mResetButton;
     Button mLookInsideButton;
     public CheckBox mCheckBox;
     float mFontScale = 4.0f;
@@ -186,7 +183,6 @@ public class MyGdxWidget extends GVRWidget {
                 }
                 table.add(slider).height(120).width(500);
             }
-
         }
 
         table.row();
@@ -206,9 +202,7 @@ public class MyGdxWidget extends GVRWidget {
         table.add(button).height(120).width(450);
         table.row();
 
-        Slider slider = null;
-
-        slider = new Slider(0, 100, 1, false, skin);
+        final Slider slider = new Slider(0, 100, 1, false, skin);
         slider.setName("Zoom");
         slider.addListener(stopTouchDown);
         Label zoom = new Label("  Zoom  ", skin);
@@ -248,7 +242,6 @@ public class MyGdxWidget extends GVRWidget {
         });
         mContainer.add(scroll).expand().fill().colspan(4);
         mContainer.row().space(10).padBottom(10);
-
     }
 
     public void render() {
@@ -280,14 +273,14 @@ public class MyGdxWidget extends GVRWidget {
             mResetSlider = false;
         }
         if (mMain.ThumbnailSelected == 1 || mMain.ThumbnailSelected == 3) {
-            ((SelectBox) mColorButtonActor).setVisible(true);
+            mColorButtonActor.setVisible(true);
 
         } else
-            ((SelectBox) mColorButtonActor).setVisible(false);
+            mColorButtonActor.setVisible(false);
         if (mMain.ThumbnailSelected == 3)
-            ((Button) mLookInsideButtonActor).setVisible(true);
+            mLookInsideButtonActor.setVisible(true);
         else
-            ((Button) mLookInsideButtonActor).setVisible(false);
+            mLookInsideButtonActor.setVisible(false);
         mStage.draw();
 
     }
@@ -299,10 +292,6 @@ public class MyGdxWidget extends GVRWidget {
 
     public void dispose() {
         mStage.dispose();
-    }
-
-    public boolean needsGL20() {
-        return false;
     }
 
 }


### PR DESCRIPTION
Set widget plugin's view size to fixed values. It doesn't have to match the display resolution. Since there are some absolute values in the gdx layout it makes things more stable.

Remove unused thumbnails-related code from gvr-widgetplugin.

Have gvr-widgetplugin call updateState after onInit to ensure the model is positioned as expected immediately after launch.

Hide the second widgetplugin pane (on the right side) of gvr-widgetviewer since there is nothing being actually drawn there. The demo needs a good amount of work to actually put the second pane to use.