### PR TITLE
Fixes build issue for travis and in general for common.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+	google()
         jcenter()
         // Gradle 4.1 and higher include support for Google's Maven repo using
         // the google() method. And you need to include this repo to download
@@ -14,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+	google()
         jcenter()
-        google()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-	google()
-        jcenter()
         // Gradle 4.1 and higher include support for Google's Maven repo using
         // the google() method. And you need to include this repo to download
         // Android plugin 3.0.0 or higher.
-        google()
+	    google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -15,7 +14,7 @@ buildscript {
 
 allprojects {
     repositories {
-	google()
+	    google()
         jcenter()
     }
 }


### PR DESCRIPTION
google() needs to be before jcenter()