### PR TITLE
gvr-immersivepedia: fix menu rendering for backends that do not support multiview

### DIFF
--- a/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/shader/CutoutShader.java
+++ b/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/shader/CutoutShader.java
@@ -18,12 +18,12 @@ package org.gearvrf.immersivepedia.shader;
 import android.content.Context;
 
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRShader;
 import org.gearvrf.GVRShaderData;
+import org.gearvrf.GVRShaderTemplate;
 import org.gearvrf.immersivepedia.R;
 import org.gearvrf.utility.TextFile;
 
-public class CutoutShader extends GVRShader{
+public class CutoutShader extends GVRShaderTemplate {
 
     public static final String TEXTURE_KEY = "u_texture";
     public static final String CUTOUT = "cutout";

--- a/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/shader/MenuImageShader.java
+++ b/gvr-immersivepedia/app/src/main/java/org/gearvrf/immersivepedia/shader/MenuImageShader.java
@@ -18,12 +18,12 @@ package org.gearvrf.immersivepedia.shader;
 import android.content.Context;
 
 import org.gearvrf.GVRContext;
-import org.gearvrf.GVRShader;
 import org.gearvrf.GVRShaderData;
+import org.gearvrf.GVRShaderTemplate;
 import org.gearvrf.immersivepedia.R;
 import org.gearvrf.utility.TextFile;
 
-public class MenuImageShader extends GVRShader {
+public class MenuImageShader extends GVRShaderTemplate {
 
     public static final String STATE1_TEXTURE = "state1";
     public static final String STATE2_TEXTURE = "state2";

--- a/gvr-immersivepedia/app/src/main/res/raw/cutout_vertex.vsh
+++ b/gvr-immersivepedia/app/src/main/res/raw/cutout_vertex.vsh
@@ -1,5 +1,3 @@
-#define HAS_MULTIVIEW 1
-
 #ifdef HAS_MULTIVIEW
 #extension GL_OVR_multiview2 : enable
 layout(num_views = 2) in;

--- a/gvr-immersivepedia/app/src/main/res/raw/menu_image_shader_fragment.vsh
+++ b/gvr-immersivepedia/app/src/main/res/raw/menu_image_shader_fragment.vsh
@@ -20,6 +20,4 @@ void main() {
 
 	outColor = textureColor;
 	outColor.a = outColor.a * u_opacity;
-
-	//outColor = vec4(1,0,0,1);
 }

--- a/gvr-immersivepedia/app/src/main/res/raw/menu_image_shader_vertex.vsh
+++ b/gvr-immersivepedia/app/src/main/res/raw/menu_image_shader_vertex.vsh
@@ -1,11 +1,11 @@
-#define HAS_MULTIVIEW 1
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
 
 #ifdef HAS_MULTIVIEW
 #extension GL_OVR_multiview2 : enable
 layout(num_views = 2) in;
 #endif
-#extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_420pack : enable
+
 precision mediump float;
 
 layout(location = 0) in vec4 a_position;


### PR DESCRIPTION
Monoscopic, daydream and other backends that do not support multiview do not show the menu quads otherwise

Was hard-coded to multiview; using shader template to have the flag set accordingly.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>