### PR TITLE
gvr-controller, daydream: add required manifest attribute

### DIFF
--- a/gvr-controller/app/src/main/AndroidManifest.xml
+++ b/gvr-controller/app/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
             android:name="org.gearvrf.sample.controller.SampleActivity"
             android:screenOrientation="landscape"
             android:label="@string/app_name"
+            android:enableVrMode="@string/gvr_vr_mode_component"
+            android:resizeableActivity="false"
             android:configChanges="orientation|keyboardHidden|screenSize">
 
             <intent-filter>


### PR DESCRIPTION
enableVrMode is required for Daydream; the app usually doesn't run on Lenovo's device without it

All apps need this update but for now this is it.

GearVRf-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>